### PR TITLE
Add port to original Xbox using nxdk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ build
 hode
 hode.ini
 setup.cfg
+*.obj
+*.exe
+*.lib
+*.iso
+bin/

--- a/Makefile.nxdk
+++ b/Makefile.nxdk
@@ -1,0 +1,31 @@
+NXDK_DIR = /home/fox/Data/Projects/XboxDev/nxdk
+
+XBE_TITLE = "Heart of Darkness"
+GEN_XISO = Heart_of_Darkness-Original_Xbox.iso
+
+CXXFLAGS = -Wall -Wpedantic
+
+SRCS += andy.cpp benchmark.cpp fileio.cpp fs_win32.cpp game.cpp \
+	level1_rock.cpp level2_fort.cpp level3_pwr1.cpp level4_isld.cpp \
+	level5_lava.cpp level6_pwr2.cpp level7_lar1.cpp level8_lar2.cpp level9_dark.cpp \
+	lzw.cpp main.cpp mdec.cpp menu.cpp mixer.cpp monsters.cpp paf.cpp random.cpp \
+	resource.cpp screenshot.cpp sound.cpp staticres.cpp system_sdl2.cpp \
+	util.cpp video.cpp
+
+SCALERS := scaler_nearest.cpp #FIXME: scaler_xbr.cpp is broken in nxdk
+
+SRCS += $(SCALERS)
+
+SRCS += 3p/libxbr-standalone/xbr.c 3p/inih/ini.c
+
+all_local: data all
+
+include $(NXDK_DIR)/Makefile
+
+data:
+	@mkdir -p $(OUTPUT_DIR)
+	cp README.txt $(OUTPUT_DIR)/
+	cp RELEASES.yaml $(OUTPUT_DIR)/
+
+NXDK_SDL = y
+include $(NXDK_DIR)/Makefile

--- a/fileio.cpp
+++ b/fileio.cpp
@@ -3,7 +3,6 @@
  * Copyright (C) 2009-2011 Gregory Montoir (cyx@users.sourceforge.net)
  */
 
-#include <sys/param.h>
 #include "fileio.h"
 #include "util.h"
 

--- a/fs_win32.cpp
+++ b/fs_win32.cpp
@@ -1,0 +1,101 @@
+
+#include <assert.h>
+#include <windows.h>
+#ifndef NXDK
+#include <stdlib.h>
+#else
+#define _MAX_PATH 200 //FIXME: Get real value for Xbox?
+#endif
+#include "fs.h"
+#include "util.h"
+
+static const char *_suffixes[] = {
+	"setup.dat",
+	"setup.dax",
+	".paf",
+	"_hod.lvl",
+	"_hod.sss",
+	"_hod.mst",
+	0
+};
+
+static bool matchGameData(const char *path) {
+	const int len = strlen(path);
+	for (int i = 0; _suffixes[i]; ++i) {
+		const int suffixLen = strlen(_suffixes[i]);
+		if (len >= suffixLen && strcasecmp(path + len - suffixLen, _suffixes[i]) == 0) {
+			return true;
+		}
+	}
+	return false;
+}
+
+FileSystem::FileSystem(const char *dataPath, const char *savePath)
+	: _dataPath(dataPath), _savePath(savePath), _filesCount(0), _filesList(0) {
+	listFiles(dataPath);
+}
+
+FileSystem::~FileSystem() {
+	for (int i = 0; i < _filesCount; ++i) {
+		free(_filesList[i]);
+	}
+	free(_filesList);
+}
+
+FILE *FileSystem::openAssetFile(const char *name) {
+	FILE *fp = 0;
+	for (int i = 0; i < _filesCount; ++i) {
+		const char *p = strrchr(_filesList[i], '\\');
+		assert(p);
+		if (strcasecmp(name, p + 1) == 0) {
+			fp = fopen(_filesList[i], "rb");
+			break;
+		}
+	}
+	return fp;
+}
+
+FILE *FileSystem::openSaveFile(const char *filename, bool write) {
+	char path[_MAX_PATH];
+	snprintf(path, sizeof(path), "%s\\%s", _savePath, filename);
+	return fopen(path, write ? "wb" : "rb");
+}
+
+int FileSystem::closeFile(FILE *fp) {
+	const int err = ferror(fp);
+	fclose(fp);
+	return err;
+}
+
+void FileSystem::addFilePath(const char *path) {
+	_filesList = (char **)realloc(_filesList, (_filesCount + 1) * sizeof(char *));
+	if (_filesList) {
+		_filesList[_filesCount] = strdup(path);
+		++_filesCount;
+	}
+}
+
+void FileSystem::listFiles(const char *dir) {
+	char filePath[_MAX_PATH];
+	WIN32_FIND_DATAA de;
+	snprintf(filePath, sizeof(filePath), "%s\\*", dir);
+	HANDLE d = FindFirstFileA(filePath, &de);
+	if (d != INVALID_HANDLE_VALUE) {
+		BOOL found = TRUE;
+		while (1) {
+			if (de.cFileName[0] == '.') {
+				continue;
+			}
+			snprintf(filePath, sizeof(filePath), "%s\\%s", dir, de.cFileName);
+			if (de.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
+				listFiles(filePath);
+			} else if (matchGameData(filePath)) {
+				addFilePath(filePath);
+			}
+			if(!FindNextFileA(d, &de)) {
+				break;
+			}
+		}
+		CloseHandle(d);
+	}
+}

--- a/system_sdl2.cpp
+++ b/system_sdl2.cpp
@@ -43,7 +43,11 @@ struct KeyMapping {
 
 struct System_SDL2 : System {
 	enum {
+#if defined(NXDK)
+		kJoystickCommitValue = 0x5000,
+#else
 		kJoystickCommitValue = 3200,
+#endif
 		kKeyMappingsSize = 20,
 		kAudioHz = 22050
 	};
@@ -590,29 +594,44 @@ void System_SDL2::processEvents() {
 			if (_controller) {
 				const bool pressed = (ev.cbutton.state == SDL_PRESSED);
 				switch (ev.cbutton.button) {
+#if defined(NXDK)
+				case SDL_CONTROLLER_BUTTON_X:
+#else
 				case SDL_CONTROLLER_BUTTON_A:
+#endif
 					if (pressed) {
 						pad.mask |= SYS_INP_RUN;
 					} else {
 						pad.mask &= ~SYS_INP_RUN;
 					}
 					break;
+#if defined(NXDK)
+				case SDL_CONTROLLER_BUTTON_A:
+#else
 				case SDL_CONTROLLER_BUTTON_B:
+#endif
 					if (pressed) {
 						pad.mask |= SYS_INP_JUMP;
 					} else {
 						pad.mask &= ~SYS_INP_JUMP;
 					}
 					break;
+#if defined(NXDK)
+				case SDL_CONTROLLER_BUTTON_B:
+				case SDL_CONTROLLER_BUTTON_Y:
+#else
 				case SDL_CONTROLLER_BUTTON_X:
+#endif
 					if (pressed) {
 						pad.mask |= SYS_INP_SHOOT;
 					} else {
 						pad.mask &= ~SYS_INP_SHOOT;
 					}
 					break;
+#if !defined(NXDK)
 				case SDL_CONTROLLER_BUTTON_Y:
 					break;
+#endif
 				case SDL_CONTROLLER_BUTTON_BACK:
 					inp.skip = pressed;
 					break;

--- a/system_sdl2.cpp
+++ b/system_sdl2.cpp
@@ -16,15 +16,23 @@ static const char *kIconBmp = "icon.bmp";
 static bool axis[4]= { false, false, false, false };
 #endif
 
+
+#if !defined(NXDK)
 static int _scalerMultiplier = 3;
 static const Scaler *_scaler = &scaler_xbr;
+#else
+static int _scalerMultiplier = 1;
+static const Scaler *_scaler = &scaler_nearest;
+#endif
 
 static const struct {
 	const char *name;
 	const Scaler *scaler;
 } _scalers[] = {
 	{ "nearest", &scaler_nearest },
+#if !defined(NXDK)
 	{ "xbr", &scaler_xbr },
+#endif
 	{ 0, 0 }
 };
 
@@ -771,15 +779,27 @@ void System_SDL2::prepareScaledGfx(const char *caption, bool fullscreen, bool wi
 	}
 	_texW = _screenW * _scalerMultiplier;
 	_texH = _screenH * _scalerMultiplier;
+#if defined(NXDK)
+	const int windowW = 640;
+	const int windowH = 480;
+	flags |= SDL_WINDOW_SHOWN;
+#else
 	const int windowW = widescreen ? _texH * 16 / 9 : _texW;
 	const int windowH = _texH;
+#endif
 	_window = SDL_CreateWindow(caption, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowW, windowH, flags);
+	assert(_window);
+#if defined(NXDK)
+	_renderer = SDL_CreateRenderer(_window, -1, 0);
+#else
 	SDL_Surface *icon = SDL_LoadBMP(kIconBmp);
 	if (icon) {
 		SDL_SetWindowIcon(_window, icon);
 		SDL_FreeSurface(icon);
 	}
 	_renderer = SDL_CreateRenderer(_window, -1, SDL_RENDERER_ACCELERATED);
+#endif
+	assert(_renderer);
 	SDL_RenderSetLogicalSize(_renderer, windowW, windowH);
 	SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "1");
 

--- a/util.cpp
+++ b/util.cpp
@@ -7,6 +7,9 @@
 #define LOG_TAG "HodJni"
 #include <android/log.h>
 #endif
+#if defined(NXDK)
+#include <hal/debug.h>
+#endif
 #include <stdarg.h>
 #include "util.h"
 
@@ -21,6 +24,9 @@ void debug(int mask, const char *msg, ...) {
 		va_end(va);
 		printf("%s\n", buf);
 		fflush(stdout);
+#if defined(NXDK)
+		debugPrint(buf);
+#endif
 #ifdef __ANDROID__
 		__android_log_print(ANDROID_LOG_INFO, LOG_TAG, "%s", buf);
 #endif
@@ -37,7 +43,12 @@ void error(const char *msg, ...) {
 #ifdef __ANDROID__
 	__android_log_print(ANDROID_LOG_ERROR, LOG_TAG, "%s", buf);
 #endif
+#if defined(NXDK)
+	debugPrint(buf);
+	while(true);
+#else
 	exit(-1);
+#endif
 }
 
 void warning(const char *msg, ...) {
@@ -49,6 +60,9 @@ void warning(const char *msg, ...) {
 	fprintf(stderr, "WARNING: %s!\n", buf);
 #ifdef __ANDROID__
 	__android_log_print(ANDROID_LOG_WARN, LOG_TAG, "%s", buf);
+#endif
+#if defined(NXDK)
+	debugPrint(buf);
 #endif
 }
 

--- a/util.h
+++ b/util.h
@@ -25,4 +25,26 @@ void debug(int mask, const char *msg, ...);
 void error(const char *msg, ...);
 void warning(const char *msg, ...);
 
+
+#if defined(NXDK)
+#include <ctype.h>
+
+static int strcasecmp(const char *s1, const char *s2) {
+  char c1 = *s1;
+  char c2 = *s2;
+  while(*s1 && *s2) {
+    c1 = tolower(*s1);
+    c2 = tolower(*s2);
+    if (c1 != c2) {
+      break;
+    }
+    s1++;
+    s2++;
+  }
+  return c1 - c2;
+}
+#else
+#include <strings.h>
+#endif
+
 #endif // UTIL_H__


### PR DESCRIPTION
Rudimentary [spite-port](https://www.urbandictionary.com/define.php?term=spite%20store) that was created after [ModernVintageGamer announced that he'd be releasing HODE for Xbox](https://twitter.com/ModernVintageG/status/1245887970265219073) built using the proprietary Xbox Development Kit that is (typically) illegally obtained.

In response, I challenged myself to create a port (within an hour or so) using the open-source and legally obtainable nxdk toolchain. In the end, it took about 3 hours (including some fine-tuning).

![Heart of Darkness running in XQEMU (Original Xbox emulator)](https://user-images.githubusercontent.com/360330/78418460-8635a780-763c-11ea-8d1f-3321a3832b59.png)


- The port loads game files from the DVD drive / D: folder (that's typically the folder where the default.xbe is).
- The port contains some native Windows support, too (intended to support more Windows toolchains).
- The button layout tries to recreate what was documented in [some Playstation guide](https://gamefaqs.gamespot.com/ps/197533-heart-of-darkness/faqs/30738).
- The game stores savegames in `E:/UDATA/hode` (in case you want to move savegames around manually).

**Requires https://github.com/XboxDev/nxdk-sdl/pull/20.**

*(Last tested on https://github.com/XboxDev/nxdk/commit/d42400df3bd8b438c818ee9f71dade1d9bb1ecb8 with https://github.com/XboxDev/nxdk-sdl/commit/0ae8796fcf303d610a87fe10da1a3b149a9d3c75)*